### PR TITLE
Remove debug print on player login

### DIFF
--- a/common/src/main/java/com/kryeit/idler/mixin/ServerPlayerMixin.java
+++ b/common/src/main/java/com/kryeit/idler/mixin/ServerPlayerMixin.java
@@ -41,7 +41,6 @@ public abstract class ServerPlayerMixin extends Entity implements AfkPlayer {
 
     @Inject(method = "<init>", at = @At("RETURN"))
     private void onPlayerLogin(CallbackInfo ci) {
-        System.out.println("Player " + idler$player.getName().getString() + " has joined the game");
         Idler.lastTimePlayed.addElement(idler$player.getUUID(), System.currentTimeMillis());
     }
 


### PR DESCRIPTION
Eliminated a System.out.println statement that logged player join events in ServerPlayerMixin. This cleans up console output and removes unnecessary debug information.